### PR TITLE
Fix timeout issue if prometheus takes more than 10 seconds to scrape.

### DIFF
--- a/aci-exporter.go
+++ b/aci-exporter.go
@@ -169,9 +169,7 @@ func main() {
 	log.Info(fmt.Sprintf("%s starting on port %d", ExporterName, viper.GetInt("port")))
 
 	s := &http.Server{
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		Addr:         ":" + strconv.Itoa(viper.GetInt("port")),
+		Addr: ":" + strconv.Itoa(viper.GetInt("port")),
 	}
 	log.Fatal(s.ListenAndServe())
 }


### PR DESCRIPTION
Prometheus fails to get metrics from aci-exporter if it takes more than 10 seconds to scrape.
This issue occurs even if `scrape_timeout` is changed to over 10 seconds.
The cause is hardcoded http.Server timeout on aci-exporter.

It works normally when I removed http.Server Read/Write timeout.
I think no problem to remove http.Server timeout because it seems other exporters are the same implementation.
(e.g. node-exporter, snmp-exporter)