### PR TITLE
Fix memory leak if api error happened

### DIFF
--- a/aci-api.go
+++ b/aci-api.go
@@ -189,6 +189,7 @@ func (p aciAPI) faults(ch chan []MetricDefinition) {
 			"fabric":    fmt.Sprintf("%v", p.ctx.Value("fabric")),
 		}).Error("faults not supported", err)
 		ch <- nil
+		return
 	}
 
 	metricDefinitionFaults := MetricDefinition{}
@@ -423,6 +424,7 @@ func (p aciAPI) getClassMetrics(ch chan []MetricDefinition, v *ClassQuery) {
 			"fabric":    fmt.Sprintf("%v", p.ctx.Value("fabric")),
 		}).Error(fmt.Sprintf("%s not supported", v.ClassName), err)
 		ch <- nil
+		return
 	}
 
 	// For each metrics in the config


### PR DESCRIPTION
Memory leak occurs per aci-exporter failed to get api.
I confirmed it is fixed by this change.
```
$ go tool pprof -top heap_result
File: aci-exporter
Type: inuse_space
Time: Mar 1, 2023 at 10:08am (JST)
Showing nodes accounting for 5585.60MB, 99.91% of 5590.61MB total
Dropped 51 nodes (cum <= 27.95MB)
      flat  flat%   sum%        cum   cum%
 2542.07MB 45.47% 45.47%  2542.57MB 45.48%  main.Metrics2Prometheus
 1417.89MB 25.36% 70.83%  1418.39MB 25.37%  main.addLabels
 1208.86MB 21.62% 92.46%  1209.36MB 21.63%  main.AciConnection.getByClassQuery
  415.28MB  7.43% 99.88%  1833.68MB 32.80%  main.aciAPI.extractClassQueriesData.func1
    1.50MB 0.027% 99.91%  3044.54MB 54.46%  main.aciAPI.getClassMetrics
```