### PR TITLE
Allow overwriting fabric credentials from environment variables

### DIFF
--- a/aci-exporter.go
+++ b/aci-exporter.go
@@ -172,6 +172,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Overwrite username or password for APIC by environment variables if set
+	for fabricName := range allFabrics {
+		fabricNameAsEnv := strings.ToUpper(strings.ReplaceAll(fabricName, "-", "_"))
+		if val, exists := os.LookupEnv(fmt.Sprintf("%s_FABRICS_%s_USERNAME", ExporterNameAsEnv(), fabricNameAsEnv)); exists == true && val != "" {
+			allFabrics[fabricName].Username = val
+		}
+		if val, exists := os.LookupEnv(fmt.Sprintf("%s_FABRICS_%s_PASSWORD", ExporterNameAsEnv(), fabricNameAsEnv)); exists == true && val != "" {
+			allFabrics[fabricName].Password = val
+		}
+	}
+
 	handler := &HandlerInit{allQueries, allFabrics}
 
 	// Create a Prometheus histogram for response time of the exporter


### PR DESCRIPTION
# Problem description
Currently, it is only possible to define the connection credentials in the config.yaml file and not over environment variables. Unfortunately, the`UnmarshalKey` method from viper only reads the values from the configuration file although `viper.AutomaticEnv` method is called at the beginning.

# Solution
Check if username or password are defined as environment variables. The environment variables are composed by the following pattern: `ACI_EXPORTER_FABRICS_{fabric name}_{USERNAME or PASSWORD}`. The fabric name used in the environment variables must be all upper case and `-` symbol will be converted to `_`

## Example
```yaml
fabrics:
  cisco_sandbox:
    username: foo
    password: bar
    apic:
      - https://sandboxapicdc.cisco.com
  profile-fabric-01:
    username: foo
    password: bar
    apic:
      - https://apic1
      - https://apic2
    aci_name: foobar
```

credentials for fabric cisco_sandbox and profile-fabric-01 can be configured as follows:

```bash
# fabric cisco_sandbox
export ACI_EXPORTER_FABRICS_CISCO_SANDBOX_USERNAME=foo 
export ACI_EXPORTER_FABRICS_CISCO_SANDBOX_PASSWORD=bar
# fabric profile-fabric-01
export ACI_EXPORTER_FABRICS_PROFILE_FABRIC_01_USERNAME=foo 
export ACI_EXPORTER_FABRICS_PROFILE_FABRIC_01_PASSWORD=bar
```
