### PR TITLE
MultiArch Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:alpine as builder
 # Set necessary environmet variables needed for our image
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64
+    GOOS=linux
 
 # Move to working directory /build
 WORKDIR /build

--- a/README.md
+++ b/README.md
@@ -577,10 +577,10 @@ To get the metrics in openmetrics format use the header `Accept: application/ope
 Please see the example file prometheus/prometheus.yml.
 
 # Docker 
-The aci-export can be build and run as a docker container. 
+The aci-export can be build and run as a docker container and it supports multi-arch.
 
 ```shell
-docker build . -t aci-exporter
+docker buildx build . -t regystry/aci-exporter:Version --platform=linux/arm64,linux/amd64 --push
 ```
 
 To run as docker use environment variables to define configuration.


### PR DESCRIPTION
In my lab I have a amd64 and arm64 K8s cluster and we can build MultiArch images but the Docker file needs a small change or it will compile go for amd64 even if the container is built for arm64