### PR TITLE
Continue Discovery even if not all fabric are working

### DIFF
--- a/aci-connection.go
+++ b/aci-connection.go
@@ -171,7 +171,7 @@ func (c *AciConnection) apicLogin(ctx context.Context) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("failed to login to any apic controllers")
+	return fmt.Errorf("failed to login to any apic controllers of fabric %s", c.fabricConfig.FabricName)
 }
 
 func (c *AciConnection) nodeLogin(ctx context.Context) error {


### PR DESCRIPTION
Currently if one fabric fails discovery no Service Discovery Data is returned at all.

This fix continues the SD process and returns data for the fabric that works. 
I am not sure however when this part of the code is called:
https://github.com/opsdis/aci-exporter/blob/issue_58_discovery/discovery.go#L52

For now my fix only affects https://github.com/opsdis/aci-exporter/blob/issue_58_discovery/discovery.go#L67 but let me know if we need to do more changes.
