### PR TITLE
up metrics continue 1 when aci node is unreachable.

### DIFF
--- a/aci-api.go
+++ b/aci-api.go
@@ -140,6 +140,11 @@ func (p aciAPI) CollectMetrics() (string, []MetricDefinition, error) {
 		metrics = append(metrics, <-ch...)
 	}
 
+	if metrics == nil {
+		metrics = append(metrics, *p.up(0.0))
+		return "", metrics, errors.New("failed to get all metrics")
+	}
+
 	end := time.Since(start)
 	metrics = append(metrics, *p.scrape(end.Seconds()))
 	metrics = append(metrics, *p.up(1.0))


### PR DESCRIPTION
`up` metrics continue 1 when aci node is unreachable(e.g. aci node down) using "node based queries".
I think if aci node is unreachable, `up` metrics shoud be goes to 0.
I added node probe per scraping.
The node probe checks aci-exporter can access to aci node or not by http request.